### PR TITLE
DEVOPS-443: Add task_role_arn output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ This Terraform module creates an Amazon ECS (Elastic Container Service) task def
 
 ## Outputs
 
-| Name                  | Description                        |
-|-----------------------|------------------------------------|
-| task_definition_arn   | The ARN of the ECS task definition  |
+| Name                  | Description                                                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------|
+| task_definition_arn   | The ARN of the ECS task definition.                                                          |
+| task_role_arn         | ARN of the task IAM role this module created, or null when `task_role_policy` was empty.     |
 
 ## Usage examples
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
 output "task_definition_arn" {
   value = aws_ecs_task_definition.main.arn
 }
+
+output "task_role_arn" {
+  value       = one(aws_iam_role.main[*].arn)
+  description = "ARN of the task IAM role this module created, or null when task_role_policy was empty (no role created)."
+}


### PR DESCRIPTION
Expose the task IAM role this module creates so callers can pass it into downstream modules (e.g. an ecs-task / SFN runner that needs iam:PassRole on the task role). Returns null when task_role_policy was empty and no role was created.